### PR TITLE
Added a .editorconfig for consistency goodness

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[{*.go,*.md,*.yaml}]
+end_of_line = lf
+max_line_length = 140
+indent_size = 2
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # vendor/
 
 dist/
+
+# Jetbrains
+.idea


### PR DESCRIPTION
Just stuff I normally use, not stuck on actual values (e.g. 2 v 4 spaces or line lengths) - but since even vim has editorconfig support I figured it might be nice to incorporate for #OCD people. 