### PR TITLE
Bit of proposed re-organization to let things grow out conceptually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 
 dist/
+cmd/tg/tg
+cmd/tgrep/tgrep

--- a/cmd/tg/main.go
+++ b/cmd/tg/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"github.com/oliverisaac/tgrep/pkg/templating"
 	"os"
 
-	"github.com/oliverisaac/tgrep/tgrep"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -14,7 +14,7 @@ func main() {
 	var parsedRegex string
 
 	for i, arg := range os.Args[1:] {
-		parsedRegex, err = tgrep.Parse(arg)
+		parsedRegex, err = templating.Parse(arg)
 		if err != nil {
 			logrus.Fatal(errors.Wrapf(err, "Parsing regex at index [%d]", i))
 		}

--- a/pkg/templating/parser.go
+++ b/pkg/templating/parser.go
@@ -1,19 +1,9 @@
-package tgrep
+package templating
 
 import (
-	"regexp"
-
 	"github.com/pkg/errors"
+	"regexp"
 )
-
-var templates = map[string]string{
-	"int":     "-?[0-9]+",
-	"number":  `-?[0-9]+(.[0-9]+)?`,
-	"uuid":    `[0-9A-Fa-f-]{8}-[0-9A-Fa-f-]{4}-[0-9A-Fa-f-]{4}-[0-9A-Fa-f-]{4}-[0-9A-Fa-f-]{12}`,
-	"integer": `[0-9]+`,
-	"email":   `[^ ]+@[^ ]+[.][^ ]+`,
-	"word":    `\b[a-zA-Z0-9-]+\b`,
-}
 
 var specialRegexCharacters = map[string]bool{
 	`[`: true,

--- a/pkg/templating/parser_test.go
+++ b/pkg/templating/parser_test.go
@@ -1,4 +1,4 @@
-package tgrep
+package templating
 
 import (
 	"testing"

--- a/pkg/templating/templates.go
+++ b/pkg/templating/templates.go
@@ -1,0 +1,10 @@
+package templating
+
+var templates = map[string]string{
+	"int":     "-?[0-9]+",
+	"number":  `-?[0-9]+(.[0-9]+)?`,
+	"uuid":    `[0-9A-Fa-f-]{8}-[0-9A-Fa-f-]{4}-[0-9A-Fa-f-]{4}-[0-9A-Fa-f-]{4}-[0-9A-Fa-f-]{12}`,
+	"integer": `[0-9]+`,
+	"email":   `[^ ]+@[^ ]+[.][^ ]+`,
+	"word":    `\b[a-zA-Z0-9-]+\b`,
+}


### PR DESCRIPTION
Since this could be quickly going down a few paths involving a bit more complexity (e.g.: stdin efficiency, abstractions on adding/managing templates via YAML or something); I thought maybe re-organizing the package a bit into more distinct components might be useful? 
